### PR TITLE
Update letsencrypt cookbook to use chef 14.X+ syntax

### DIFF
--- a/letsencrypt/resources/snakeoil_cleanup.rb
+++ b/letsencrypt/resources/snakeoil_cleanup.rb
@@ -9,6 +9,9 @@ property :root, String, required: true
 default_action :run
 
 action :run do
+  server = new_resource.server
+  root = new_resource.root
+
   # cleanup a failed attempt
   # TODO: check to make sure it is a webroot conf file
   renew_conf_f = ::File.join(root, "renewal", "#{server}.conf")

--- a/letsencrypt/resources/snakeoil_create.rb
+++ b/letsencrypt/resources/snakeoil_create.rb
@@ -15,6 +15,9 @@ property :cert_root, String, required: true
 default_action :run
 
 action :run do
+  domain = new_resource.domain
+  snakeoil_root = new_resource.snakeoil_root
+  cert_root = new_resource.cert_root
 
   so_cert = Letsencrypt::Cert.new(snakeoil_root, domain)
 
@@ -51,7 +54,7 @@ action :run do
 #     #action :nothing
 #     not_if { le_cert.exists?() }
 #   end
-# 
+#
 #   link "#{name} #{rname} symlink cert #{domain}" do
 #     target_file ::File.join(cert_d, domain, so_cert.cert_name)
 #     to so_cert.cert_f


### PR DESCRIPTION
Not sure how you want to test this. Changes were made due to breaking changes in Chef 14

> Property names not using new_resource.NAME
> Previously if a user wrote a custom resource with a property named foo they could reference it throughout the resource using the name foo. This caused multiple edge cases where the property name could conflict with resources or methods in Chef. Properties now must be referenced as new_resource.foo. This was already the case when writing LWRPs.

Ref: https://docs.chef.io/release_notes.html#id46